### PR TITLE
Unzip dynawo into parent directory of the current step's workspace

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
           DYNAWO_VERSION: 1.3.1
         run: |
           wget https://github.com/dynawo/dynawo/releases/download/v${DYNAWO_VERSION}/Dynawo_Linux_v${DYNAWO_VERSION}.zip
-          unzip Dynawo_Linux_v${DYNAWO_VERSION}.zip
+          unzip Dynawo_Linux_v${DYNAWO_VERSION}.zip -d ..
           rm -f Dynawo_Linux_v${DYNAWO_VERSION}.zip
 
       - name: Checkout network store sources


### PR DESCRIPTION
Using the parent directory to avoid unziped dynawo to be removed at the checkout "dynamic-simulation-server" step