### PR TITLE
Remove temporary directory created in config dir by the ParametersService

### DIFF
--- a/src/main/java/org/gridsuite/ds/server/service/parameters/impl/ParametersServiceImpl.java
+++ b/src/main/java/org/gridsuite/ds/server/service/parameters/impl/ParametersServiceImpl.java
@@ -52,6 +52,7 @@ public class ParametersServiceImpl implements ParametersService {
         try (InputStream eventsIs = getClass().getResourceAsStream(PARAMETERS_DIR + RESOURCE_PATH_DELIMETER + EVENTS_PAR)) {
             // prepare a temp dir for current running simulation
             Path configDir = PlatformConfig.defaultConfig().getConfigDir().orElseThrow();
+            // TODO to remove when dynawaltz provider support streams for inputs
             Path workingDir = Files.createTempDirectory(configDir, WORKING_DIR_PREFIX);
 
             // merge dynamicParams with events.par then load parametersFile in a runtime tmp directory


### PR DESCRIPTION
Dynawaltz provider actually works with file-based inputs, so a temporary directory is created in the same file system of  ConfigDir.
At the end of the computation, we need remove this tempo directory.

TODO  in future : when dynawaltz provider supports stream-based inputs, we must remove these codes