### PR TITLE
Dynamic Simulation - Fix unit test

### DIFF
--- a/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationWorkerService.java
+++ b/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationWorkerService.java
@@ -97,7 +97,6 @@ public class DynamicSimulationWorkerService {
         List<CurveGroovyExtension> curveExtensions = GroovyExtension.find(CurveGroovyExtension.class, DynaWaltzProvider.NAME);
         CurvesSupplier curvesSupplier = new GroovyCurvesSupplier(new ByteArrayInputStream(context.getCurveContent()), curveExtensions);
 
-        LOGGER.info("Provider in run = ", context.getProvider());
         return Mono.fromCompletionStage(runAsync(network,
                 context.getProvider(),
                 context.getVariantId() != null ? context.getVariantId() : VariantManagerConstants.INITIAL_VARIANT_ID,
@@ -114,7 +113,6 @@ public class DynamicSimulationWorkerService {
                                                                EventModelsSupplier eventModelsSupplier,
                                                                CurvesSupplier curvesSupplier,
                                                                DynamicSimulationParameters dynamicSimulationParameters) {
-        LOGGER.info("Provider = ", provider);
         DynamicSimulation.Runner runner = DynamicSimulation.find(provider);
         return runner.runAsync(network, dynamicModelsSupplier, eventModelsSupplier, curvesSupplier, variantId, dynamicSimulationParameters);
     }

--- a/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationWorkerService.java
+++ b/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationWorkerService.java
@@ -97,6 +97,7 @@ public class DynamicSimulationWorkerService {
         List<CurveGroovyExtension> curveExtensions = GroovyExtension.find(CurveGroovyExtension.class, DynaWaltzProvider.NAME);
         CurvesSupplier curvesSupplier = new GroovyCurvesSupplier(new ByteArrayInputStream(context.getCurveContent()), curveExtensions);
 
+        LOGGER.info("Provider in run = ", context.getProvider());
         return Mono.fromCompletionStage(runAsync(network,
                 context.getProvider(),
                 context.getVariantId() != null ? context.getVariantId() : VariantManagerConstants.INITIAL_VARIANT_ID,
@@ -113,6 +114,7 @@ public class DynamicSimulationWorkerService {
                                                                EventModelsSupplier eventModelsSupplier,
                                                                CurvesSupplier curvesSupplier,
                                                                DynamicSimulationParameters dynamicSimulationParameters) {
+        LOGGER.info("Provider = ", provider);
         DynamicSimulation.Runner runner = DynamicSimulation.find(provider);
         return runner.runAsync(network, dynamicModelsSupplier, eventModelsSupplier, curvesSupplier, variantId, dynamicSimulationParameters);
     }

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerIEEE14Test.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerIEEE14Test.java
@@ -98,6 +98,11 @@ public class DynamicSimulationControllerIEEE14Test extends AbstractDynamicSimula
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
 
     @Override
+    public OutputDestination getOutputDestination() {
+        return output;
+    }
+
+    @Override
     protected void initNetworkStoreServiceMock() {
         ReadOnlyDataSource dataSource = new ResourceDataSource("IEEE14",
                 new ResourceSet(DATA_IEEE14_BASE_DIR, NETWORK_FILE));
@@ -184,7 +189,7 @@ public class DynamicSimulationControllerIEEE14Test extends AbstractDynamicSimula
 
         UUID runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        Message<byte[]> messageSwitch = output.receive(1000 * 5, "ds.result.destination");
+        Message<byte[]> messageSwitch = output.receive(1000 * 5, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(DynamicSimulationResultContext.HEADER_RESULT_UUID).toString()));
 
         try {
@@ -229,7 +234,7 @@ public class DynamicSimulationControllerIEEE14Test extends AbstractDynamicSimula
         UUID runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
         // Message failed must be sent
-        Message<byte[]> messageSwitch = output.receive(1000 * 5, "ds.failed.destination");
+        Message<byte[]> messageSwitch = output.receive(1000 * 5, dsFailedDestination);
 
         // check uuid and failed message
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
@@ -79,6 +79,11 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
     private static final boolean RESULT = true;
 
     @Override
+    public OutputDestination getOutputDestination() {
+        return output;
+    }
+
+    @Override
     protected void initNetworkStoreServiceMock() {
         ReadOnlyDataSource dataSource = new ResourceDataSource("IEEE14",
                 new ResourceSet("", TEST_FILE));
@@ -151,8 +156,8 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         UUID runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        Message<byte[]> messageSwitch = output.receive(1000 * 5, "ds.result.destination");
-        assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get("resultUuid").toString()));
+        Message<byte[]> messageSwitch = output.receive(1000 * 5, dsResultDestination);
+        assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //run the dynamic simulation on the implicit default variant
         entityExchangeResult = webTestClient.post()
@@ -165,8 +170,8 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        messageSwitch = output.receive(1000, "ds.result.destination");
-        assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get("resultUuid").toString()));
+        messageSwitch = output.receive(1000, dsResultDestination);
+        assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //get the calculation status
         EntityExchangeResult<DynamicSimulationStatus> entityExchangeResult2 = webTestClient.get()
@@ -259,7 +264,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        messageSwitch = output.receive(1000 * 5, "ds.failed.destination");
+        messageSwitch = output.receive(1000 * 5, dsFailedDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
         assertEquals(FAIL_MESSAGE + " : " + HttpStatus.NOT_FOUND, messageSwitch.getHeaders().get(HEADER_MESSAGE));
     }


### PR DESCRIPTION
Fix unit test for PR : https://github.com/gridsuite/dynamic-simulation-server/pull/49
**Build :** https://github.com/gridsuite/dynamic-simulation-server/actions/runs/4639660296/jobs/8272702301

**Error:**  Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3.329 s <<< FAILURE! - in org.gridsuite.ds.server.controller.DynamicSimulationControllerIEEE14Test
Error:  test01GivenRunWithException  Time elapsed: 0.152 s  <<< FAILURE!
java.lang.AssertionError: expected:<264936bd-5f70-4e91-bb5f-1e6ec18de2e8> but was:<b664ee35-ea8b-4b7e-9382-a6eef97e0341>
	at org.gridsuite.ds.server.controller.DynamicSimulationControllerIEEE14Test.test01GivenRunWithException(DynamicSimulationControllerIEEE14Test.java:235)

**Reason:** a fail message is not consumed by a previous test but by the next test.. 