### PR TITLE
Fix Liquibase `diff` when JPA entities not modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target/
 # IntelliJ
 /.idea
 *.iml
+
+# https://github.com/liquibase/liquibase/issues/2196
+/derby.log

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent-ws</artifactId>
-        <version>17</version>
+        <version>18</version>
         <relativePath/>
     </parent>
 

--- a/src/main/resources/db/changelog/changesets/changelog_20221206T145803Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20221206T145803Z.xml
@@ -1,5 +1,9 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd" logicalFilePath="db/changelog/changesets/changelog_2022-12-06T14:58:03Z.xml">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd" logicalFilePath="db/changelog/changesets/changelog_2022-12-06T14:58:03Z.xml">
     <changeSet author="phamquy (generated)" id="1670338689731-1">
         <addColumn tableName="result">
             <column name="time_line_uuid" type="uuid"/>
@@ -15,5 +19,10 @@
         <addColumn tableName="result">
             <column name="result" type="UUID"/>
         </addColumn>
+    </changeSet>
+
+    <changeSet author="chuinetri (generated)" id="1697569949532-1">
+        <comment>Missing update from #37</comment>
+        <dropColumn columnName="result" tableName="result"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/test/resources/application-default.yml
+++ b/src/test/resources/application-default.yml
@@ -15,5 +15,5 @@ logging:
 powsybl-ws:
   database:
     vendor: h2:mem
-    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;DEFAULT_NULL_ORDERING=HIGH
     hostPort: ":"


### PR DESCRIPTION
Liquibase `diff` generate changes when using `main` branch without modifying JPA entities.  
* The diff is from #37, where the field [`result` was removed](/gridsuite/dynamic-simulation-server/pull/37/files#diff-3e9851838366c7a8a53564c8e520c82940de1348df560692211c105f987bd69a) but [deleted then recreated in the changelog](https://github.com/gridsuite/dynamic-simulation-server/pull/37/files#diff-6864b082859cd271a65972c35316556f1abb3dc3fb485462db4f2d72550b8e01).
* Also add missing compatibility mode in H2 configuration
* ⚠️ need release v18 of powsybl/powsybl-parent/pull/54