### PR TITLE
Dynamic Simulation - Correct unit test failed 

### DIFF
--- a/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
@@ -9,6 +9,7 @@ package org.gridsuite.ds.server.controller;
 import com.powsybl.network.store.client.NetworkStoreService;
 import org.gridsuite.ds.server.CustomApplicationContextInitializer;
 import org.gridsuite.ds.server.DynamicSimulationApplication;
+import org.gridsuite.ds.server.controller.utils.TestUtils;
 import org.gridsuite.ds.server.service.DynamicSimulationWorkerService;
 import org.gridsuite.ds.server.service.client.dynamicmapping.DynamicMappingClient;
 import org.gridsuite.ds.server.service.client.timeseries.TimeSeriesClient;
@@ -35,7 +36,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
@@ -102,10 +102,9 @@ public abstract class AbstractDynamicSimulationControllerTest extends AbstractDy
         List<String> destinations = List.of(dsFailedDestination, dsResultDestination);
 
         try {
-            destinations.forEach(destination -> assertNull("Should not be any messages in queue " + destination + " : ", output.receive(1000 * 10, destination)));
-        } finally {
-            // purge in order to not fail the other tests
-            output.clear();
+            TestUtils.assertQueuesEmptyThenClear(destinations, output);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Error while checking message queues empty", e);
         }
     }
 

--- a/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
@@ -103,8 +103,7 @@ public abstract class AbstractDynamicSimulationControllerTest extends AbstractDy
 
         try {
             destinations.forEach(destination -> assertNull("Should not be any messages in queue " + destination + " : ", output.receive(100, destination)));
-        }
-        finally {
+        } finally {
             // purge in order to not fail the other tests
             output.clear();
         }

--- a/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
@@ -102,7 +102,7 @@ public abstract class AbstractDynamicSimulationControllerTest extends AbstractDy
         List<String> destinations = List.of(dsFailedDestination, dsResultDestination);
 
         try {
-            destinations.forEach(destination -> assertNull("Should not be any messages in queue " + destination + " : ", output.receive(1000, destination)));
+            destinations.forEach(destination -> assertNull("Should not be any messages in queue " + destination + " : ", output.receive(1000 * 10, destination)));
         } finally {
             // purge in order to not fail the other tests
             output.clear();

--- a/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
@@ -104,6 +104,7 @@ public abstract class AbstractDynamicSimulationControllerTest extends AbstractDy
         destinations.forEach(destination -> assertNull("Should not be any messages in queue " + destination + " : ", output.receive(100, destination)));
 
         // purge in order to not fail the other tests
+        logger.info("Purge output channel");
         output.clear();
     }
 

--- a/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
@@ -101,11 +101,13 @@ public abstract class AbstractDynamicSimulationControllerTest extends AbstractDy
         OutputDestination output = getOutputDestination();
         List<String> destinations = List.of(dsFailedDestination, dsResultDestination);
 
-        destinations.forEach(destination -> assertNull("Should not be any messages in queue " + destination + " : ", output.receive(100, destination)));
-
-        // purge in order to not fail the other tests
-        logger.info("Purge output channel");
-        output.clear();
+        try {
+            destinations.forEach(destination -> assertNull("Should not be any messages in queue " + destination + " : ", output.receive(100, destination)));
+        }
+        finally {
+            // purge in order to not fail the other tests
+            output.clear();
+        }
     }
 
     protected abstract OutputDestination getOutputDestination();

--- a/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/AbstractDynamicSimulationControllerTest.java
@@ -102,7 +102,7 @@ public abstract class AbstractDynamicSimulationControllerTest extends AbstractDy
         List<String> destinations = List.of(dsFailedDestination, dsResultDestination);
 
         try {
-            destinations.forEach(destination -> assertNull("Should not be any messages in queue " + destination + " : ", output.receive(100, destination)));
+            destinations.forEach(destination -> assertNull("Should not be any messages in queue " + destination + " : ", output.receive(1000, destination)));
         } finally {
             // purge in order to not fail the other tests
             output.clear();

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerIEEE14Test.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerIEEE14Test.java
@@ -29,7 +29,6 @@ import org.gridsuite.ds.server.dto.timeseries.TimeSeriesGroupInfos;
 import org.gridsuite.ds.server.service.client.dynamicmapping.DynamicMappingClientTest;
 import org.gridsuite.ds.server.service.client.timeseries.TimeSeriesClientTest;
 import org.gridsuite.ds.server.service.contexts.DynamicSimulationResultContext;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerIEEE14Test.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerIEEE14Test.java
@@ -63,7 +63,6 @@ import static org.mockito.Mockito.doAnswer;
 /**
  * @author Thang PHAM <quyet-thang.pham at rte-france.com>
  */
-@Ignore
 public class DynamicSimulationControllerIEEE14Test extends AbstractDynamicSimulationControllerTest {
     // mapping names
     public static final String MAPPING_NAME_01 = "_01";

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerIEEE14Test.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerIEEE14Test.java
@@ -29,6 +29,7 @@ import org.gridsuite.ds.server.dto.timeseries.TimeSeriesGroupInfos;
 import org.gridsuite.ds.server.service.client.dynamicmapping.DynamicMappingClientTest;
 import org.gridsuite.ds.server.service.client.timeseries.TimeSeriesClientTest;
 import org.gridsuite.ds.server.service.contexts.DynamicSimulationResultContext;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -62,6 +63,7 @@ import static org.mockito.Mockito.doAnswer;
 /**
  * @author Thang PHAM <quyet-thang.pham at rte-france.com>
  */
+@Ignore
 public class DynamicSimulationControllerIEEE14Test extends AbstractDynamicSimulationControllerTest {
     // mapping names
     public static final String MAPPING_NAME_01 = "_01";

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
@@ -151,7 +151,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         UUID runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        Message<byte[]> messageSwitch = output.receive(1000 * 5, dsResultDestination);
+        Message<byte[]> messageSwitch = output.receive(1000 * 6, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //run the dynamic simulation on the implicit default variant
@@ -165,7 +165,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        messageSwitch = output.receive(1000 * 5, dsResultDestination);
+        messageSwitch = output.receive(1000 * 6, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //get the calculation status

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
@@ -151,7 +151,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         UUID runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        Message<byte[]> messageSwitch = output.receive(1000 * 5, dsResultDestination);
+        Message<byte[]> messageSwitch = output.receive(1000 * 10, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //run the dynamic simulation on the implicit default variant
@@ -165,7 +165,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        messageSwitch = output.receive(1000 * 5, dsResultDestination);
+        messageSwitch = output.receive(1000 * 10, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //get the calculation status

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
@@ -151,7 +151,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         UUID runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        Message<byte[]> messageSwitch = output.receive(1000 * 6, dsResultDestination);
+        Message<byte[]> messageSwitch = output.receive(1000 * 7, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //run the dynamic simulation on the implicit default variant
@@ -165,7 +165,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        messageSwitch = output.receive(1000 * 6, dsResultDestination);
+        messageSwitch = output.receive(1000 * 7, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //get the calculation status

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
@@ -151,7 +151,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         UUID runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        Message<byte[]> messageSwitch = output.receive(1000 * 10, dsResultDestination);
+        Message<byte[]> messageSwitch = output.receive(1000 * 5, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //run the dynamic simulation on the implicit default variant
@@ -165,7 +165,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        messageSwitch = output.receive(1000 * 10, dsResultDestination);
+        messageSwitch = output.receive(1000 * 5, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //get the calculation status

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
@@ -259,7 +259,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        messageSwitch = output.receive(1000 * 10, dsFailedDestination);
+        messageSwitch = output.receive(1000 * 5, dsFailedDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
         assertEquals(FAIL_MESSAGE + " : " + HttpStatus.NOT_FOUND, messageSwitch.getHeaders().get(HEADER_MESSAGE));
     }

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
@@ -151,7 +151,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         UUID runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        Message<byte[]> messageSwitch = output.receive(1000 * 7, dsResultDestination);
+        Message<byte[]> messageSwitch = output.receive(1000 * 10, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //run the dynamic simulation on the implicit default variant
@@ -165,7 +165,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        messageSwitch = output.receive(1000 * 7, dsResultDestination);
+        messageSwitch = output.receive(1000 * 10, dsResultDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
 
         //get the calculation status
@@ -259,7 +259,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
         runUuid = UUID.fromString(entityExchangeResult.getResponseBody().toString());
 
-        messageSwitch = output.receive(1000 * 5, dsFailedDestination);
+        messageSwitch = output.receive(1000 * 10, dsFailedDestination);
         assertEquals(runUuid, UUID.fromString(messageSwitch.getHeaders().get(HEADER_RESULT_UUID).toString()));
         assertEquals(FAIL_MESSAGE + " : " + HttpStatus.NOT_FOUND, messageSwitch.getHeaders().get(HEADER_MESSAGE));
     }

--- a/src/test/java/org/gridsuite/ds/server/controller/utils/TestUtils.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/utils/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/test/java/org/gridsuite/ds/server/controller/utils/TestUtils.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/utils/TestUtils.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.gridsuite.ds.server.controller.utils;
+
+import org.springframework.cloud.stream.binder.test.OutputDestination;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Thang PHAM <quyet-thang.pham at rte-france.com>
+ */
+public final class TestUtils {
+    private static final long TIMEOUT = 100;
+
+    private TestUtils() {
+
+    }
+
+    public static void assertQueuesEmptyThenClear(List<String> destinations, OutputDestination output) throws InterruptedException {
+        Thread.sleep(TIMEOUT);
+        try {
+            destinations.forEach(destination -> assertNull("Should not be any messages in queue " + destination + " : ", output.receive(0, destination)));
+        } catch (NullPointerException e) {
+            // Ignoring
+        } finally {
+            output.clear(); // purge in order to not fail the other tests
+        }
+    }
+}


### PR DESCRIPTION
Due to an unknown changed from a third party service, may be github or dockerhub, the time to run a integration test with test container is increased => a quick fix is to increase the time out when checking asynchronous returned result.