### PR TITLE
Handle user id and shorten error messages

### DIFF
--- a/src/main/java/org/gridsuite/ds/server/controller/DynamicSimulationController.java
+++ b/src/main/java/org/gridsuite/ds/server/controller/DynamicSimulationController.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.gridsuite.ds.server.DynamicSimulationApi.API_VERSION;
+import static org.gridsuite.ds.server.service.contexts.DynamicSimulationFailedContext.HEADER_USER_ID;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
@@ -48,8 +49,9 @@ public class DynamicSimulationController {
                                           @RequestParam(name = "receiver", required = false) String receiver,
                                           @RequestParam("mappingName") String mappingName,
                                           @RequestParam(name = "provider", required = false) String provider,
-                                          @RequestBody DynamicSimulationParametersInfos parameters) {
-        Mono<UUID> resultUuid = dynamicSimulationService.runAndSaveResult(receiver, networkUuid, variantId, mappingName, provider, parameters);
+                                          @RequestBody DynamicSimulationParametersInfos parameters,
+                                          @RequestHeader(HEADER_USER_ID) String userId) {
+        Mono<UUID> resultUuid = dynamicSimulationService.runAndSaveResult(receiver, networkUuid, variantId, mappingName, provider, parameters, userId);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(resultUuid);
     }
 

--- a/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationService.java
+++ b/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationService.java
@@ -30,7 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>

--- a/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationService.java
+++ b/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationService.java
@@ -62,7 +62,7 @@ public class DynamicSimulationService {
         this.parametersService = Objects.requireNonNull(parametersService);
     }
 
-    public Mono<UUID> runAndSaveResult(String receiver, UUID networkUuid, String variantId, String mappingName, String provider, DynamicSimulationParametersInfos parametersInfos) {
+    public Mono<UUID> runAndSaveResult(String receiver, UUID networkUuid, String variantId, String mappingName, String provider, DynamicSimulationParametersInfos parametersInfos, String userId) {
 
         // check provider => if not found then set default provider
         String dsProvider = getProviders().stream()
@@ -85,7 +85,7 @@ public class DynamicSimulationService {
                     byte[] eventModel = parametersService.getEventModel(parametersInfos.getEvents());
                     byte[] curveModel = parametersService.getCurveModel(parametersInfos.getCurves());
 
-                    DynamicSimulationRunContext runContext = new DynamicSimulationRunContext(dsProvider, receiver, networkUuid, variantId, dynamicModel, eventModel, curveModel, parameters);
+                    DynamicSimulationRunContext runContext = new DynamicSimulationRunContext(dsProvider, receiver, networkUuid, variantId, dynamicModel, eventModel, curveModel, parameters, userId);
 
                     return insertStatus(DynamicSimulationStatus.RUNNING.name()) // update status to running status
                             .map(resultEntity -> {
@@ -108,7 +108,7 @@ public class DynamicSimulationService {
             // set entity with new values
             resultEntities.forEach(resultEntity -> resultEntity.setStatus(status));
             // save entities into database
-            return resultRepository.saveAllAndFlush(resultEntities).stream().map(ResultEntity::getId).collect(Collectors.toList());
+            return resultRepository.saveAllAndFlush(resultEntities).stream().map(ResultEntity::getId).toList();
         });
     }
 
@@ -155,7 +155,7 @@ public class DynamicSimulationService {
     public List<String> getProviders() {
         return DynamicSimulationProvider.findAll().stream()
                 .map(DynamicSimulationProvider::getName)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public String getDefaultProvider() {

--- a/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationWorkerService.java
+++ b/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationWorkerService.java
@@ -157,7 +157,9 @@ public class DynamicSimulationWorkerService {
                     // send fail notification
                     Message<String> sendMessage = new DynamicSimulationFailedContext(resultContext.getRunContext().getReceiver(),
                             resultContext.getResultUuid(),
-                            FAIL_MESSAGE + " : " + e.getMessage()).toMessage();
+                            FAIL_MESSAGE + " : " + e.getMessage(),
+                            resultContext.getRunContext().getUserId()
+                            ).toMessage();
 
                     notificationService.emitFailDynamicSimulationMessage(sendMessage);
                     // delete result entity in server's db

--- a/src/main/java/org/gridsuite/ds/server/service/contexts/DynamicSimulationFailedContext.java
+++ b/src/main/java/org/gridsuite/ds/server/service/contexts/DynamicSimulationFailedContext.java
@@ -55,12 +55,8 @@ public class DynamicSimulationFailedContext {
             return msg;
         }
 
-        String shortMsg = msg;
-        if (shortMsg.length() > MSG_MAX_LENGTH) {
-            shortMsg = msg.substring(0, MSG_MAX_LENGTH / 2) +
-                    " ... " +
-                    msg.substring(msg.length() - MSG_MAX_LENGTH / 2, msg.length() - 1);
-        }
-        return shortMsg;
+        return msg.length() > MSG_MAX_LENGTH ?
+                msg.substring(0, MSG_MAX_LENGTH / 2) + " ... " + msg.substring(msg.length() - MSG_MAX_LENGTH / 2, msg.length() - 1)
+                : msg;
     }
 }

--- a/src/main/java/org/gridsuite/ds/server/service/contexts/DynamicSimulationResultContext.java
+++ b/src/main/java/org/gridsuite/ds/server/service/contexts/DynamicSimulationResultContext.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import static org.gridsuite.ds.server.service.contexts.ContextUtils.getNonNullHeader;
+import static org.gridsuite.ds.server.service.contexts.DynamicSimulationFailedContext.HEADER_USER_ID;
 
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
@@ -63,12 +64,13 @@ public class DynamicSimulationResultContext {
         String receiver = (String) headers.get(HEADER_RECEIVER);
         UUID networkUuid = UUID.fromString(getNonNullHeader(headers, HEADER_NETWORK_UUID));
         String variantId = (String) headers.get(HEADER_VARIANT_ID);
+        String userId = (String) headers.get(HEADER_USER_ID);
         byte[] dynamicModelContent = (byte[]) headers.get(HEADER_DYNAMIC_MODEL_CONTENT);
         byte[] eventModelContent = (byte[]) headers.get(HEADER_EVENT_MODEL_CONTENT);
         byte[] curveContent = (byte[]) headers.get(HEADER_CURVE_CONTENT);
         // decode the parameters
 
-        DynamicSimulationRunContext runContext = new DynamicSimulationRunContext(provider, receiver, networkUuid, variantId, dynamicModelContent, eventModelContent, curveContent, parameters);
+        DynamicSimulationRunContext runContext = new DynamicSimulationRunContext(provider, receiver, networkUuid, variantId, dynamicModelContent, eventModelContent, curveContent, parameters, userId);
         return new DynamicSimulationResultContext(resultUuid, runContext);
     }
 
@@ -86,6 +88,7 @@ public class DynamicSimulationResultContext {
                 .setHeader(HEADER_DYNAMIC_MODEL_CONTENT, runContext.getDynamicModelContent())
                 .setHeader(HEADER_EVENT_MODEL_CONTENT, runContext.getEventModelContent())
                 .setHeader(HEADER_CURVE_CONTENT, runContext.getCurveContent())
+                .setHeader(HEADER_USER_ID, runContext.getUserId())
                 .build();
     }
 

--- a/src/main/java/org/gridsuite/ds/server/service/contexts/DynamicSimulationRunContext.java
+++ b/src/main/java/org/gridsuite/ds/server/service/contexts/DynamicSimulationRunContext.java
@@ -7,6 +7,7 @@
 package org.gridsuite.ds.server.service.contexts;
 
 import com.powsybl.dynamicsimulation.DynamicSimulationParameters;
+import lombok.Getter;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -14,6 +15,7 @@ import java.util.UUID;
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
  */
+@Getter
 public class DynamicSimulationRunContext {
 
     private final String provider;
@@ -31,8 +33,10 @@ public class DynamicSimulationRunContext {
     private final byte[] curveContent;
 
     private final DynamicSimulationParameters parameters;
+    private final String userId;
 
-    public DynamicSimulationRunContext(String provider, String receiver, UUID networkUuid, String variantId, byte[] dynamicModelContent, byte[] eventModelContent, byte[] curveContent, DynamicSimulationParameters parameters) {
+    public DynamicSimulationRunContext(String provider, String receiver, UUID networkUuid, String variantId, byte[] dynamicModelContent,
+                                       byte[] eventModelContent, byte[] curveContent, DynamicSimulationParameters parameters, String userId) {
         this.provider = provider;
         this.receiver = receiver;
         this.networkUuid = Objects.requireNonNull(networkUuid);
@@ -41,37 +45,7 @@ public class DynamicSimulationRunContext {
         this.eventModelContent = eventModelContent;
         this.curveContent = curveContent;
         this.parameters = parameters;
-    }
-
-    public String getProvider() {
-        return provider;
-    }
-
-    public String getReceiver() {
-        return receiver; }
-
-    public UUID getNetworkUuid() {
-        return networkUuid;
-    }
-
-    public String getVariantId() {
-        return variantId;
-    }
-
-    public byte[] getDynamicModelContent() {
-        return dynamicModelContent;
-    }
-
-    public byte[] getEventModelContent() {
-        return eventModelContent;
-    }
-
-    public byte[] getCurveContent() {
-        return curveContent;
-    }
-
-    public DynamicSimulationParameters getParameters() {
-        return parameters;
+        this.userId = userId;
     }
 }
 

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerIEEE14Test.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerIEEE14Test.java
@@ -51,6 +51,7 @@ import java.util.stream.Collectors;
 
 import static org.gridsuite.ds.server.service.contexts.DynamicSimulationFailedContext.HEADER_MESSAGE;
 import static org.gridsuite.ds.server.service.contexts.DynamicSimulationFailedContext.HEADER_RESULT_UUID;
+import static org.gridsuite.ds.server.service.contexts.DynamicSimulationFailedContext.HEADER_USER_ID;
 import static org.gridsuite.ds.server.service.notification.NotificationService.FAIL_MESSAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -204,6 +205,7 @@ public class DynamicSimulationControllerIEEE14Test extends AbstractDynamicSimula
         EntityExchangeResult<UUID> entityExchangeResult = webTestClient.post()
                 .uri("/v1/networks/{networkUuid}/run?" + "&mappingName=" + MAPPING_NAME_01, NETWORK_UUID_STRING)
                 .bodyValue(parameters)
+                .header(HEADER_USER_ID, "testUserId")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(UUID.class)
@@ -264,6 +266,7 @@ public class DynamicSimulationControllerIEEE14Test extends AbstractDynamicSimula
         EntityExchangeResult<UUID> entityExchangeResult = webTestClient.post()
                 .uri("/v1/networks/{networkUuid}/run?" + "&mappingName=" + MAPPING_NAME_01, NETWORK_UUID_STRING)
                 .bodyValue(parameters)
+                .header(HEADER_USER_ID, "testUserId")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(UUID.class)

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.gridsuite.ds.server.service.contexts.DynamicSimulationFailedContext.HEADER_MESSAGE;
 import static org.gridsuite.ds.server.service.contexts.DynamicSimulationFailedContext.HEADER_RESULT_UUID;
+import static org.gridsuite.ds.server.service.contexts.DynamicSimulationFailedContext.HEADER_USER_ID;
 import static org.gridsuite.ds.server.service.notification.NotificationService.FAIL_MESSAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -144,6 +145,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
         EntityExchangeResult<UUID> entityExchangeResult = webTestClient.post()
                 .uri("/v1/networks/{networkUuid}/run?variantId=" + VARIANT_1_ID + "&mappingName=" + MAPPING_NAME, NETWORK_UUID_STRING)
                 .bodyValue(parameters)
+                .header(HEADER_USER_ID, "testUserId")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(UUID.class)
@@ -158,6 +160,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
         entityExchangeResult = webTestClient.post()
                 .uri("/v1/networks/{networkUuid}/run?" + "&mappingName=" + MAPPING_NAME, NETWORK_UUID_STRING)
                 .bodyValue(parameters)
+                .header(HEADER_USER_ID, "testUserId")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(UUID.class)
@@ -252,6 +255,7 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
         entityExchangeResult = webTestClient.post()
                 .uri("/v1/networks/{networkUuid}/run?" + "&mappingName=" + MAPPING_NAME, NETWORK_UUID_NOT_FOUND_STRING)
                 .bodyValue(parameters)
+                .header(HEADER_USER_ID, "testUserId")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(UUID.class)


### PR DESCRIPTION
1 Bug fix : The full error message is still logged but only a shortened version is sent through rabbitmq (prevents it from crashing).

2. userId is added to the run context and transmitted in the messages (because it is needed in order to display the error messages on the front side)