### PR TITLE
Dynamic Simulation - Exception when running simulation without curves

### DIFF
--- a/src/main/java/org/gridsuite/ds/server/controller/DynamicSimulationController.java
+++ b/src/main/java/org/gridsuite/ds/server/controller/DynamicSimulationController.java
@@ -58,31 +58,34 @@ public class DynamicSimulationController {
     @GetMapping(value = "/results/{resultUuid}/timeseries", produces = "application/json")
     @Operation(summary = "Get a dynamic simulation result from the database")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The dynamic simulation result"),
-        @ApiResponse(responseCode = "404", description = "Dynamic simulation result has not been found")})
+        @ApiResponse(responseCode = "204", description = "Dynamic simulation series uuid is empty"),
+        @ApiResponse(responseCode = "404", description = "Dynamic simulation result uuid has not been found")})
     public Mono<ResponseEntity<UUID>> getTimeSeriesResult(@Parameter(description = "Result UUID") @PathVariable("resultUuid") UUID resultUuid) {
         Mono<UUID> result = dynamicSimulationService.getTimeSeriesId(resultUuid);
         return result.map(r -> ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(r))
-                .defaultIfEmpty(ResponseEntity.notFound().build());
+                .defaultIfEmpty(ResponseEntity.noContent().build());
     }
 
     @GetMapping(value = "/results/{resultUuid}/timeline", produces = "application/json")
     @Operation(summary = "Get a dynamic simulation result from the database")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The dynamic simulation result"),
-        @ApiResponse(responseCode = "404", description = "Dynamic simulation result has not been found")})
+        @ApiResponse(responseCode = "204", description = "Dynamic simulation timeline uuid is empty"),
+        @ApiResponse(responseCode = "404", description = "Dynamic simulation result uuid has not been found")})
     public Mono<ResponseEntity<UUID>> getTimeLineResult(@Parameter(description = "Result UUID") @PathVariable("resultUuid") UUID resultUuid) {
         Mono<UUID> result = dynamicSimulationService.getTimeLineId(resultUuid);
         return result.map(r -> ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(r))
-                .defaultIfEmpty(ResponseEntity.notFound().build());
+                .defaultIfEmpty(ResponseEntity.noContent().build());
     }
 
     @GetMapping(value = "/results/{resultUuid}/status", produces = "application/json")
     @Operation(summary = "Get the dynamic simulation status from the database")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The dynamic simulation status"),
-        @ApiResponse(responseCode = "404", description = "Dynamic simulation status has not been found")})
+        @ApiResponse(responseCode = "204", description = "Dynamic simulation status is empty"),
+        @ApiResponse(responseCode = "404", description = "Dynamic simulation result uuid has not been found")})
     public Mono<ResponseEntity<DynamicSimulationStatus>> getStatus(@Parameter(description = "Result UUID") @PathVariable("resultUuid") UUID resultUuid) {
         Mono<DynamicSimulationStatus> result = dynamicSimulationService.getStatus(resultUuid);
         return result.map(r -> ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(r))
-                .defaultIfEmpty(ResponseEntity.notFound().build());
+                .defaultIfEmpty(ResponseEntity.noContent().build());
     }
 
     @PutMapping(value = "/results/invalidate-status", produces = "application/json")

--- a/src/main/java/org/gridsuite/ds/server/service/client/timeseries/impl/TimeSeriesClientImpl.java
+++ b/src/main/java/org/gridsuite/ds/server/service/client/timeseries/impl/TimeSeriesClientImpl.java
@@ -12,6 +12,7 @@ import org.gridsuite.ds.server.service.client.timeseries.TimeSeriesClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -34,6 +35,9 @@ public class TimeSeriesClientImpl implements TimeSeriesClient {
 
     @Override
     public Mono<TimeSeriesGroupInfos> sendTimeSeries(List<TimeSeries> timeSeriesList) {
+        if (CollectionUtils.isEmpty(timeSeriesList)) {
+            return Mono.just(new TimeSeriesGroupInfos(null));
+        }
 
         // convert timeseries to json
         var timeSeriesListJson = TimeSeries.toJson(timeSeriesList);


### PR DESCRIPTION
**Corrections in this PR:**

1. Do not send post request to time-series-server when simulation result has an empty timeseries or timeline
2. Correct the return http code to '204' in case of lacking timeseries or timeline uuid for get APIs

**Related PRs:**

GridStudy-app : https://github.com/gridsuite/gridstudy-app/pull/1870 (with demo)
Study-server : https://github.com/gridsuite/study-server/pull/514