### PR TITLE
Get multiple statuses at once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
         <string-template.version>4.3.1</string-template.version>
         <sonar.organization>gridsuite</sonar.organization>
         <sonar.projectKey>org.gridsuite:dynamic-simulation-server</sonar.projectKey>
+        <!-- FIXME: to be removed at next powsybl-ws-dependencies upgrade  -->
+        <gridsuite-computation.version>2.3.0-SNAPSHOT</gridsuite-computation.version>
     </properties>
 
     <build>
@@ -107,6 +109,7 @@
         <dependency>
             <groupId>org.gridsuite</groupId>
             <artifactId>gridsuite-computation</artifactId>
+            <version>${gridsuite-computation.version}</version>
         </dependency>
         <dependency>
             <groupId>org.gridsuite</groupId>

--- a/src/main/java/org/gridsuite/ds/server/controller/DynamicSimulationController.java
+++ b/src/main/java/org/gridsuite/ds/server/controller/DynamicSimulationController.java
@@ -26,6 +26,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.gridsuite.computation.service.NotificationService.HEADER_USER_ID;
@@ -110,6 +111,13 @@ public class DynamicSimulationController {
     public ResponseEntity<DynamicSimulationStatus> getStatus(@Parameter(description = "Result UUID") @PathVariable("resultUuid") UUID resultUuid) {
         DynamicSimulationStatus result = dynamicSimulationResultService.findStatus(resultUuid);
         return ResponseEntity.ok().body(result);
+    }
+
+    @PostMapping(value = "/results/statuses", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    @Operation(summary = "Get dynamic simulation statuses from the database")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The dynamic simulation statuses")})
+    public ResponseEntity<Map<UUID, DynamicSimulationStatus>> getStatuses(@Parameter(description = "Result uuids") @RequestBody List<UUID> resultUuids) {
+        return ResponseEntity.ok().body(dynamicSimulationResultService.findStatuses(resultUuids));
     }
 
     @GetMapping(value = "/results/{resultUuid}/output-state", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)

--- a/src/main/java/org/gridsuite/ds/server/repository/ResultRepository.java
+++ b/src/main/java/org/gridsuite/ds/server/repository/ResultRepository.java
@@ -26,8 +26,6 @@ import java.util.UUID;
 public interface ResultRepository extends JpaRepository<ResultEntity, UUID> {
     <T> Optional<T> findById(UUID id, Class<T> type);
 
-    List<ResultEntity> findByResultUuidIn(List<UUID> resultUuids);
-
     <T> List<T> findBy(Class<T> type);
 
     @Modifying

--- a/src/main/java/org/gridsuite/ds/server/repository/ResultRepository.java
+++ b/src/main/java/org/gridsuite/ds/server/repository/ResultRepository.java
@@ -6,6 +6,7 @@
  */
 package org.gridsuite.ds.server.repository;
 
+import org.apache.poi.ss.formula.functions.T;
 import org.gridsuite.ds.server.dto.DynamicSimulationStatus;
 import org.gridsuite.ds.server.entities.ResultEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,6 +25,8 @@ import java.util.UUID;
 @Repository
 public interface ResultRepository extends JpaRepository<ResultEntity, UUID> {
     <T> Optional<T> findById(UUID id, Class<T> type);
+
+    List<ResultEntity> findByResultUuidIn(List<UUID> resultUuids);
 
     <T> List<T> findBy(Class<T> type);
 

--- a/src/main/java/org/gridsuite/ds/server/repository/ResultRepository.java
+++ b/src/main/java/org/gridsuite/ds/server/repository/ResultRepository.java
@@ -6,7 +6,6 @@
  */
 package org.gridsuite.ds.server.repository;
 
-import org.apache.poi.ss.formula.functions.T;
 import org.gridsuite.ds.server.dto.DynamicSimulationStatus;
 import org.gridsuite.ds.server.entities.ResultEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationResultService.java
+++ b/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationResultService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.gridsuite.computation.error.ComputationBusinessErrorCode.RESULT_NOT_FOUND;
 
@@ -150,6 +151,14 @@ public class DynamicSimulationResultService extends AbstractComputationResultSer
         return resultRepository.findById(resultUuid, ResultEntity.BasicFields.class)
                 .map(ResultEntity.BasicFields::getStatus)
                 .orElse(null);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<UUID, DynamicSimulationStatus> findStatuses(List<UUID> resultUuids) {
+        Objects.requireNonNull(resultUuids);
+        List<ResultEntity> resultEntities = resultRepository.findByResultUuidIn(resultUuids);
+        return resultEntities.stream().collect(Collectors.toMap(ResultEntity::getId, ResultEntity::getStatus));
     }
 
     @Override

--- a/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationResultService.java
+++ b/src/main/java/org/gridsuite/ds/server/service/DynamicSimulationResultService.java
@@ -157,7 +157,7 @@ public class DynamicSimulationResultService extends AbstractComputationResultSer
     @Transactional(readOnly = true)
     public Map<UUID, DynamicSimulationStatus> findStatuses(List<UUID> resultUuids) {
         Objects.requireNonNull(resultUuids);
-        List<ResultEntity> resultEntities = resultRepository.findByResultUuidIn(resultUuids);
+        List<ResultEntity> resultEntities = resultRepository.findAllById(resultUuids);
         return resultEntities.stream().collect(Collectors.toMap(ResultEntity::getId, ResultEntity::getStatus));
     }
 

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
@@ -65,6 +65,8 @@ import static org.gridsuite.computation.service.NotificationService.*;
 import static org.gridsuite.ds.server.controller.utils.TestUtils.assertType;
 import static org.gridsuite.ds.server.service.DynamicSimulationService.COMPUTATION_TYPE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -402,6 +404,89 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
 
     }
 
+    @Test
+    public void testStatus() throws Exception {
+        Map<String, DoubleTimeSeries> curves = new HashMap<>();
+        List<TimelineEvent> timeLine = List.of();
+        Map<String, Double> finalStateValues = new HashMap<>();
+
+        doReturn(CompletableFuture.completedFuture(new DynamicSimulationResultImpl(DynamicSimulationResult.Status.SUCCESS, "", curves, finalStateValues, timeLine)))
+                .when(dynamicSimulationWorkerService).getCompletableFuture(any(), any(), any());
+
+        List<EventInfos> events = List.of();
+
+        MvcResult result = mockMvc.perform(
+                post("/v1/networks/{networkUuid}/run", NETWORK_UUID_STRING)
+                    .param("variantId", VARIANT_1_ID)
+                    .param("parametersUuid", PARAMETERS_UUID.toString())
+                    .contentType(APPLICATION_JSON)
+                    .header(HEADER_USER_ID, "testUserId")
+                    .content(objectMapper.writeValueAsString(events)))
+                .andExpect(status().isOk())
+                .andReturn();
+        UUID runUuid = objectMapper.readValue(result.getResponse().getContentAsString(), UUID.class);
+
+        Message<byte[]> messageSwitch = output.receive(1000, dsResultDestination);
+        assertThat(messageSwitch.getHeaders()).containsEntry(HEADER_RESULT_UUID, runUuid.toString());
+
+        MvcResult statusResult = mockMvc.perform(
+                get("/v1/results/{resultUuid}/status", runUuid))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        DynamicSimulationStatus status = objectMapper.readValue(statusResult.getResponse().getContentAsString(), DynamicSimulationStatus.class);
+        assertThat(status).isSameAs(DynamicSimulationStatus.CONVERGED);
+
+        MvcResult missingStatusResult = mockMvc.perform(
+                get("/v1/results/{resultUuid}/status", UUID.randomUUID()))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertThat(missingStatusResult.getResponse().getContentAsString()).isEmpty();
+    }
+
+    @Test
+    public void testStatuses() throws Exception {
+        Map<String, DoubleTimeSeries> curves = new HashMap<>();
+        List<TimelineEvent> timeLine = List.of();
+        Map<String, Double> finalStateValues = new HashMap<>();
+
+        doReturn(CompletableFuture.completedFuture(new DynamicSimulationResultImpl(DynamicSimulationResult.Status.SUCCESS, "", curves, finalStateValues, timeLine)))
+                .when(dynamicSimulationWorkerService).getCompletableFuture(any(), any(), any());
+
+        List<EventInfos> events = List.of();
+
+        MvcResult result = mockMvc.perform(
+                post("/v1/networks/{networkUuid}/run", NETWORK_UUID_STRING)
+                    .param("variantId", VARIANT_1_ID)
+                    .param("parametersUuid", PARAMETERS_UUID.toString())
+                    .contentType(APPLICATION_JSON)
+                    .header(HEADER_USER_ID, "testUserId")
+                    .content(objectMapper.writeValueAsString(events)))
+                .andExpect(status().isOk())
+                .andReturn();
+        UUID runUuid = objectMapper.readValue(result.getResponse().getContentAsString(), UUID.class);
+
+        Message<byte[]> messageSwitch = output.receive(1000, dsResultDestination);
+        assertThat(messageSwitch.getHeaders()).containsEntry(HEADER_RESULT_UUID, runUuid.toString());
+
+        UUID unknownResultUuid = UUID.randomUUID();
+        MvcResult statusesResult = mockMvc.perform(
+                post("/v1/results/statuses")
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(List.of(runUuid, unknownResultUuid)))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<UUID, DynamicSimulationStatus> statuses = objectMapper.readValue(
+                statusesResult.getResponse().getContentAsString(),
+                objectMapper.getTypeFactory().constructMapType(Map.class, UUID.class, DynamicSimulationStatus.class));
+
+        assertThat(statuses).hasSize(1);
+        assertThat(statuses).containsKey(runUuid);
+        assertThat(statuses.get(runUuid)).isSameAs(DynamicSimulationStatus.CONVERGED);
+    }
+
     // --- BEGIN Test cancelling a running computation ---//
     private void mockSendRunMessage(Supplier<CompletableFuture<?>> runAsyncMock) {
         // In test environment, the test binder calls consumers directly in the caller thread, i.e. the controller thread.
@@ -579,136 +664,4 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
         assertResultStatus(runUuid, status().isOk());
     }
     // --- END Test cancelling a running computation ---//
-
-    @Test
-    public void testStatuses() throws Exception {
-        // mock DynamicSimulationWorkerService with time-series and timeline
-        Map<String, DoubleTimeSeries> curves = new HashMap<>();
-        TimeSeriesIndex index = new IrregularTimeSeriesIndex(new long[]{32, 64, 128, 256});
-        curves.put("NETWORK__BUS____2-BUS____5-1_AC_iSide2", TimeSeries.createDouble("NETWORK__BUS____2-BUS____5-1_AC_iSide2", index, 333.847331, 333.847321, 333.847300, 333.847259));
-        curves.put("NETWORK__BUS____1_TN_Upu_value", TimeSeries.createDouble("NETWORK__BUS____1_TN_Upu_value", index, 1.059970, 1.059970, 1.059970, 1.059970));
-
-        List<TimelineEvent> timeLine = List.of(
-                new TimelineEvent(102479, "CLA_2_5 - CLA", "order to change topology"),
-                new TimelineEvent(102479, "_BUS____2-BUS____5-1_AC - LINE", "opening both sides")
-        );
-
-        Map<String, Double> finalStateValues = new HashMap<>();
-
-        doReturn(CompletableFuture.completedFuture(new DynamicSimulationResultImpl(DynamicSimulationResult.Status.SUCCESS, "", curves, finalStateValues, timeLine)))
-                .when(dynamicSimulationWorkerService).getCompletableFuture(any(), any(), any());
-
-        // prepare content
-        List<EventInfos> events = List.of();
-
-        // Run first dynamic simulation
-        MvcResult result1 = mockMvc.perform(
-                post("/v1/networks/{networkUuid}/run", NETWORK_UUID_STRING)
-                    .param("variantId", VARIANT_1_ID)
-                    .param("parametersUuid", PARAMETERS_UUID.toString())
-                    .contentType(APPLICATION_JSON)
-                    .header(HEADER_USER_ID, "testUserId")
-                    .content(objectMapper.writeValueAsString(events)))
-                .andExpect(status().isOk())
-                .andReturn();
-        UUID runUuid1 = objectMapper.readValue(result1.getResponse().getContentAsString(), UUID.class);
-
-        // check notification of result
-        Message<byte[]> messageSwitch = output.receive(1000 * 10, dsResultDestination);
-        assertThat(messageSwitch.getHeaders()).containsEntry(HEADER_RESULT_UUID, runUuid1.toString());
-
-        // Run second dynamic simulation
-        MvcResult result2 = mockMvc.perform(
-                post("/v1/networks/{networkUuid}/run", NETWORK_UUID_STRING)
-                    .param("variantId", VARIANT_1_ID)
-                    .param("parametersUuid", PARAMETERS_UUID.toString())
-                    .contentType(APPLICATION_JSON)
-                    .header(HEADER_USER_ID, "testUserId")
-                    .content(objectMapper.writeValueAsString(events)))
-                .andExpect(status().isOk())
-                .andReturn();
-        UUID runUuid2 = objectMapper.readValue(result2.getResponse().getContentAsString(), UUID.class);
-
-        // check notification of result
-        messageSwitch = output.receive(1000 * 10, dsResultDestination);
-        assertThat(messageSwitch.getHeaders()).containsEntry(HEADER_RESULT_UUID, runUuid2.toString());
-
-        // Run third dynamic simulation
-        MvcResult result3 = mockMvc.perform(
-                post("/v1/networks/{networkUuid}/run", NETWORK_UUID_STRING)
-                    .param("variantId", VARIANT_1_ID)
-                    .param("parametersUuid", PARAMETERS_UUID.toString())
-                    .contentType(APPLICATION_JSON)
-                    .header(HEADER_USER_ID, "testUserId")
-                    .content(objectMapper.writeValueAsString(events)))
-                .andExpect(status().isOk())
-                .andReturn();
-        UUID runUuid3 = objectMapper.readValue(result3.getResponse().getContentAsString(), UUID.class);
-
-        // check notification of result
-        messageSwitch = output.receive(1000 * 10, dsResultDestination);
-        assertThat(messageSwitch.getHeaders()).containsEntry(HEADER_RESULT_UUID, runUuid3.toString());
-
-        // Wait for all simulations to complete
-        await().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> true);
-
-        // Get statuses of all results at once
-        List<UUID> resultUuids = List.of(runUuid1, runUuid2, runUuid3);
-        MvcResult statusesResult = mockMvc.perform(
-                post("/v1/results/statuses")
-                    .contentType(APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(resultUuids)))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        // Parse the response map of statuses
-        @SuppressWarnings("unchecked")
-        Map<String, String> statusesMap = objectMapper.readValue(statusesResult.getResponse().getContentAsString(), Map.class);
-
-        // Verify that all three results are in the response
-        assertThat(statusesMap).hasSize(3);
-        assertThat(statusesMap.keySet()).containsExactlyInAnyOrder(
-                runUuid1.toString(),
-                runUuid2.toString(),
-                runUuid3.toString()
-        );
-
-        // Verify that all statuses are CONVERGED
-        assertThat(statusesMap.values()).allMatch(status -> status.equals(DynamicSimulationStatus.CONVERGED.name()));
-
-        // Test with non-existing UUID mixed with existing ones
-        UUID nonExistingUuid = UUID.randomUUID();
-        List<UUID> mixedUuids = List.of(runUuid1, nonExistingUuid, runUuid2);
-        MvcResult mixedStatusesResult = mockMvc.perform(
-                post("/v1/results/statuses")
-                    .contentType(APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(mixedUuids)))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        @SuppressWarnings("unchecked")
-        Map<String, String> mixedStatusesMap = objectMapper.readValue(mixedStatusesResult.getResponse().getContentAsString(), Map.class);
-
-        // Should only contain existing results
-        assertThat(mixedStatusesMap).hasSize(2);
-        assertThat(mixedStatusesMap.keySet()).containsExactlyInAnyOrder(
-                runUuid1.toString(),
-                runUuid2.toString()
-        );
-
-        // Test with empty list
-        MvcResult emptyResult = mockMvc.perform(
-                post("/v1/results/statuses")
-                    .contentType(APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(List.of())))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        @SuppressWarnings("unchecked")
-        Map<String, String> emptyMap = objectMapper.readValue(emptyResult.getResponse().getContentAsString(), Map.class);
-
-        // Should return an empty map
-        assertThat(emptyMap).isEmpty();
-    }
-
 }

--- a/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
+++ b/src/test/java/org/gridsuite/ds/server/controller/DynamicSimulationControllerTest.java
@@ -580,4 +580,135 @@ public class DynamicSimulationControllerTest extends AbstractDynamicSimulationCo
     }
     // --- END Test cancelling a running computation ---//
 
+    @Test
+    public void testStatuses() throws Exception {
+        // mock DynamicSimulationWorkerService with time-series and timeline
+        Map<String, DoubleTimeSeries> curves = new HashMap<>();
+        TimeSeriesIndex index = new IrregularTimeSeriesIndex(new long[]{32, 64, 128, 256});
+        curves.put("NETWORK__BUS____2-BUS____5-1_AC_iSide2", TimeSeries.createDouble("NETWORK__BUS____2-BUS____5-1_AC_iSide2", index, 333.847331, 333.847321, 333.847300, 333.847259));
+        curves.put("NETWORK__BUS____1_TN_Upu_value", TimeSeries.createDouble("NETWORK__BUS____1_TN_Upu_value", index, 1.059970, 1.059970, 1.059970, 1.059970));
+
+        List<TimelineEvent> timeLine = List.of(
+                new TimelineEvent(102479, "CLA_2_5 - CLA", "order to change topology"),
+                new TimelineEvent(102479, "_BUS____2-BUS____5-1_AC - LINE", "opening both sides")
+        );
+
+        Map<String, Double> finalStateValues = new HashMap<>();
+
+        doReturn(CompletableFuture.completedFuture(new DynamicSimulationResultImpl(DynamicSimulationResult.Status.SUCCESS, "", curves, finalStateValues, timeLine)))
+                .when(dynamicSimulationWorkerService).getCompletableFuture(any(), any(), any());
+
+        // prepare content
+        List<EventInfos> events = List.of();
+
+        // Run first dynamic simulation
+        MvcResult result1 = mockMvc.perform(
+                post("/v1/networks/{networkUuid}/run", NETWORK_UUID_STRING)
+                    .param("variantId", VARIANT_1_ID)
+                    .param("parametersUuid", PARAMETERS_UUID.toString())
+                    .contentType(APPLICATION_JSON)
+                    .header(HEADER_USER_ID, "testUserId")
+                    .content(objectMapper.writeValueAsString(events)))
+                .andExpect(status().isOk())
+                .andReturn();
+        UUID runUuid1 = objectMapper.readValue(result1.getResponse().getContentAsString(), UUID.class);
+
+        // check notification of result
+        Message<byte[]> messageSwitch = output.receive(1000 * 10, dsResultDestination);
+        assertThat(messageSwitch.getHeaders()).containsEntry(HEADER_RESULT_UUID, runUuid1.toString());
+
+        // Run second dynamic simulation
+        MvcResult result2 = mockMvc.perform(
+                post("/v1/networks/{networkUuid}/run", NETWORK_UUID_STRING)
+                    .param("variantId", VARIANT_1_ID)
+                    .param("parametersUuid", PARAMETERS_UUID.toString())
+                    .contentType(APPLICATION_JSON)
+                    .header(HEADER_USER_ID, "testUserId")
+                    .content(objectMapper.writeValueAsString(events)))
+                .andExpect(status().isOk())
+                .andReturn();
+        UUID runUuid2 = objectMapper.readValue(result2.getResponse().getContentAsString(), UUID.class);
+
+        // check notification of result
+        messageSwitch = output.receive(1000 * 10, dsResultDestination);
+        assertThat(messageSwitch.getHeaders()).containsEntry(HEADER_RESULT_UUID, runUuid2.toString());
+
+        // Run third dynamic simulation
+        MvcResult result3 = mockMvc.perform(
+                post("/v1/networks/{networkUuid}/run", NETWORK_UUID_STRING)
+                    .param("variantId", VARIANT_1_ID)
+                    .param("parametersUuid", PARAMETERS_UUID.toString())
+                    .contentType(APPLICATION_JSON)
+                    .header(HEADER_USER_ID, "testUserId")
+                    .content(objectMapper.writeValueAsString(events)))
+                .andExpect(status().isOk())
+                .andReturn();
+        UUID runUuid3 = objectMapper.readValue(result3.getResponse().getContentAsString(), UUID.class);
+
+        // check notification of result
+        messageSwitch = output.receive(1000 * 10, dsResultDestination);
+        assertThat(messageSwitch.getHeaders()).containsEntry(HEADER_RESULT_UUID, runUuid3.toString());
+
+        // Wait for all simulations to complete
+        await().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> true);
+
+        // Get statuses of all results at once
+        List<UUID> resultUuids = List.of(runUuid1, runUuid2, runUuid3);
+        MvcResult statusesResult = mockMvc.perform(
+                post("/v1/results/statuses")
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(resultUuids)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // Parse the response map of statuses
+        @SuppressWarnings("unchecked")
+        Map<String, String> statusesMap = objectMapper.readValue(statusesResult.getResponse().getContentAsString(), Map.class);
+
+        // Verify that all three results are in the response
+        assertThat(statusesMap).hasSize(3);
+        assertThat(statusesMap.keySet()).containsExactlyInAnyOrder(
+                runUuid1.toString(),
+                runUuid2.toString(),
+                runUuid3.toString()
+        );
+
+        // Verify that all statuses are CONVERGED
+        assertThat(statusesMap.values()).allMatch(status -> status.equals(DynamicSimulationStatus.CONVERGED.name()));
+
+        // Test with non-existing UUID mixed with existing ones
+        UUID nonExistingUuid = UUID.randomUUID();
+        List<UUID> mixedUuids = List.of(runUuid1, nonExistingUuid, runUuid2);
+        MvcResult mixedStatusesResult = mockMvc.perform(
+                post("/v1/results/statuses")
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mixedUuids)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> mixedStatusesMap = objectMapper.readValue(mixedStatusesResult.getResponse().getContentAsString(), Map.class);
+
+        // Should only contain existing results
+        assertThat(mixedStatusesMap).hasSize(2);
+        assertThat(mixedStatusesMap.keySet()).containsExactlyInAnyOrder(
+                runUuid1.toString(),
+                runUuid2.toString()
+        );
+
+        // Test with empty list
+        MvcResult emptyResult = mockMvc.perform(
+                post("/v1/results/statuses")
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(List.of())))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> emptyMap = objectMapper.readValue(emptyResult.getResponse().getContentAsString(), Map.class);
+
+        // Should return an empty map
+        assertThat(emptyMap).isEmpty();
+    }
+
 }


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
feat(): Add POST "/results/statuses" endpoint to get multiple statuses at once given a collection of resultUuids in body


